### PR TITLE
feat: add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+__pycache__
+.env
+tests/
+*.pyc
+.venv/
+*.md
+.gitignore
+.github/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY src/ ./src/
+
+EXPOSE 8000
+
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -12,11 +12,26 @@ This is a thin routing layer with no business logic.
 
 ## Quick Start
 
+### Local Development
+
 ```bash
 pip install -r requirements.txt
 cp .env.example .env
 uvicorn src.main:app --reload --port 8000
 # Swagger docs at http://localhost:8000/docs
+```
+
+### Docker
+
+```bash
+# Build the image
+docker build -t beat-books-api .
+
+# Run the container
+docker run -p 8000:8000 beat-books-api
+
+# Health check
+curl http://localhost:8000/
 ```
 
 ## Endpoints


### PR DESCRIPTION
Closes #3

Adds Docker support for the API gateway service:

- Created Dockerfile based on Python 3.11-slim
- Added .dockerignore to exclude unnecessary files
- Updated README with Docker build and run commands

The Dockerfile follows best practices:
- Uses slim base image for minimal size
- No secrets baked into image
- Configuration via environment variables
- Properly exposes port 8000

Generated with [Claude Code](https://claude.ai/code)