### PR TITLE
feat: wire prediction routes to beat-books-model service

### DIFF
--- a/src/routes/predictions.py
+++ b/src/routes/predictions.py
@@ -1,11 +1,206 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field, validator
+from typing import Optional, List, Literal
+import httpx
+from src.core.config import settings
 
 router = APIRouter()
 
-# TODO: Wire these to beat-books-model service (Phase 2)
+# Valid NFL team abbreviations (32 teams)
+VALID_NFL_TEAMS = {
+    "cardinals", "falcons", "ravens", "bills", "panthers", "bears", "bengals", "browns",
+    "cowboys", "broncos", "lions", "packers", "texans", "colts", "jaguars", "chiefs",
+    "raiders", "chargers", "rams", "dolphins", "vikings", "patriots", "saints", "giants",
+    "jets", "eagles", "steelers", "49ers", "seahawks", "buccaneers", "titans", "commanders"
+}
 
 
-@router.get("/predict")
-def predict_game(team1: str, team2: str):
-    """Predict game outcome. Delegates to beat-books-model."""
-    return {"message": f"{team1} vs {team2} prediction — not yet wired to beat-books-model"}
+# Response Models
+class PredictionResponse(BaseModel):
+    """Response model for game prediction."""
+    home_team: str
+    away_team: str
+    home_win_probability: float = Field(..., ge=0.0, le=1.0)
+    away_win_probability: float = Field(..., ge=0.0, le=1.0)
+    predicted_spread: float
+    model_version: str
+    feature_version: str
+    edge_vs_market: float
+    recommended_bet_size: float = Field(..., ge=0.0, le=1.0)
+    bet_recommendation: Literal["BET", "NO_BET"]
+
+
+class BacktestResponse(BaseModel):
+    """Response model for backtest results."""
+    run_id: str
+    start_date: str
+    end_date: str
+    total_games: int
+    correct_predictions: int
+    accuracy: float = Field(..., ge=0.0, le=1.0)
+    total_profit: float
+    roi: float
+    sharpe_ratio: Optional[float] = None
+
+
+class ModelInfo(BaseModel):
+    """Response model for model information."""
+    model_id: str
+    model_version: str
+    feature_version: str
+    trained_date: str
+    accuracy: float = Field(..., ge=0.0, le=1.0)
+    is_active: bool
+
+
+class ModelsListResponse(BaseModel):
+    """Response model for list of models."""
+    models: List[ModelInfo]
+
+
+def validate_team_name(team: str) -> str:
+    """Validate and normalize NFL team name."""
+    normalized = team.lower().strip()
+    if normalized not in VALID_NFL_TEAMS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid team name: '{team}'. Must be a valid NFL team abbreviation (e.g., chiefs, eagles, patriots)."
+        )
+    return normalized
+
+
+@router.get("/predict", response_model=PredictionResponse)
+async def predict_game(
+    team1: str = Query(..., description="Home team name (NFL team abbreviation)"),
+    team2: str = Query(..., description="Away team name (NFL team abbreviation)")
+):
+    """
+    Predict game outcome between two teams.
+
+    Delegates to beat-books-model service for prediction computation.
+
+    Args:
+        team1: Home team name (NFL abbreviation, e.g., 'chiefs')
+        team2: Away team name (NFL abbreviation, e.g., 'eagles')
+
+    Returns:
+        PredictionResponse with probabilities, spread, and betting recommendation
+
+    Raises:
+        HTTPException: 400 if team names are invalid
+        HTTPException: 503 if model service is unavailable
+    """
+    # Validate team names
+    home_team = validate_team_name(team1)
+    away_team = validate_team_name(team2)
+
+    # Delegate to beat-books-model service
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"{settings.MODEL_SERVICE_URL}/predict",
+                params={"team1": home_team, "team2": away_team},
+                timeout=10.0
+            )
+            response.raise_for_status()
+            return response.json()
+    except httpx.ConnectError:
+        raise HTTPException(
+            status_code=503,
+            detail="Model service unavailable. Please ensure beat-books-model is running."
+        )
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(
+            status_code=e.response.status_code,
+            detail=f"Model service error: {e.response.text}"
+        )
+    except httpx.TimeoutException:
+        raise HTTPException(
+            status_code=504,
+            detail="Model service timeout. Request took too long."
+        )
+
+
+@router.get("/backtest/{run_id}", response_model=BacktestResponse)
+async def get_backtest_results(run_id: str):
+    """
+    Retrieve backtest results by run ID.
+
+    Delegates to beat-books-model service to fetch backtest results.
+
+    Args:
+        run_id: Unique identifier for the backtest run
+
+    Returns:
+        BacktestResponse with accuracy, profit, ROI, and other metrics
+
+    Raises:
+        HTTPException: 404 if backtest run not found
+        HTTPException: 503 if model service is unavailable
+    """
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"{settings.MODEL_SERVICE_URL}/backtest/{run_id}",
+                timeout=10.0
+            )
+            response.raise_for_status()
+            return response.json()
+    except httpx.ConnectError:
+        raise HTTPException(
+            status_code=503,
+            detail="Model service unavailable. Please ensure beat-books-model is running."
+        )
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Backtest run '{run_id}' not found."
+            )
+        raise HTTPException(
+            status_code=e.response.status_code,
+            detail=f"Model service error: {e.response.text}"
+        )
+    except httpx.TimeoutException:
+        raise HTTPException(
+            status_code=504,
+            detail="Model service timeout. Request took too long."
+        )
+
+
+@router.get("/models", response_model=ModelsListResponse)
+async def list_models():
+    """
+    List all available trained models.
+
+    Delegates to beat-books-model service to retrieve model metadata.
+
+    Returns:
+        ModelsListResponse with list of available models and their metadata
+
+    Raises:
+        HTTPException: 503 if model service is unavailable
+    """
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"{settings.MODEL_SERVICE_URL}/models",
+                timeout=10.0
+            )
+            response.raise_for_status()
+            return response.json()
+    except httpx.ConnectError:
+        raise HTTPException(
+            status_code=503,
+            detail="Model service unavailable. Please ensure beat-books-model is running."
+        )
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(
+            status_code=e.response.status_code,
+            detail=f"Model service error: {e.response.text}"
+        )
+    except httpx.TimeoutException:
+        raise HTTPException(
+            status_code=504,
+            detail="Model service timeout. Request took too long."
+        )

--- a/tests/test_routes/test_predictions.py
+++ b/tests/test_routes/test_predictions.py
@@ -1,0 +1,242 @@
+import pytest
+from unittest.mock import patch, AsyncMock
+from fastapi import status
+import httpx
+
+
+class TestPredictEndpoint:
+    """Tests for GET /predictions/predict endpoint."""
+
+    @patch("httpx.AsyncClient.get")
+    @pytest.mark.asyncio
+    async def test_predict_game_success(self, mock_get, client):
+        """Test successful game prediction."""
+        # Mock response from beat-books-model service
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "home_team": "chiefs",
+            "away_team": "eagles",
+            "home_win_probability": 0.62,
+            "away_win_probability": 0.38,
+            "predicted_spread": -3.5,
+            "model_version": "v1.0",
+            "feature_version": "v1.0",
+            "edge_vs_market": 0.04,
+            "recommended_bet_size": 0.025,
+            "bet_recommendation": "BET"
+        }
+        mock_response.raise_for_status = AsyncMock()
+        mock_get.return_value = mock_response
+
+        # Make request
+        response = client.get("/predictions/predict?team1=chiefs&team2=eagles")
+
+        # Assertions
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["home_team"] == "chiefs"
+        assert data["away_team"] == "eagles"
+        assert data["home_win_probability"] == 0.62
+        assert data["bet_recommendation"] == "BET"
+
+    def test_predict_game_invalid_team1(self, client):
+        """Test prediction with invalid home team name."""
+        response = client.get("/predictions/predict?team1=invalid&team2=eagles")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Invalid team name" in response.json()["detail"]
+
+    def test_predict_game_invalid_team2(self, client):
+        """Test prediction with invalid away team name."""
+        response = client.get("/predictions/predict?team1=chiefs&team2=invalid")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Invalid team name" in response.json()["detail"]
+
+    def test_predict_game_missing_team1(self, client):
+        """Test prediction with missing team1 parameter."""
+        response = client.get("/predictions/predict?team2=eagles")
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_predict_game_missing_team2(self, client):
+        """Test prediction with missing team2 parameter."""
+        response = client.get("/predictions/predict?team1=chiefs")
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    @patch("httpx.AsyncClient.get")
+    @pytest.mark.asyncio
+    async def test_predict_game_service_unavailable(self, mock_get, client):
+        """Test prediction when model service is unavailable."""
+        mock_get.side_effect = httpx.ConnectError("Connection refused")
+
+        response = client.get("/predictions/predict?team1=chiefs&team2=eagles")
+
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert "Model service unavailable" in response.json()["detail"]
+
+    @patch("httpx.AsyncClient.get")
+    @pytest.mark.asyncio
+    async def test_predict_game_service_timeout(self, mock_get, client):
+        """Test prediction when model service times out."""
+        mock_get.side_effect = httpx.TimeoutException("Request timeout")
+
+        response = client.get("/predictions/predict?team1=chiefs&team2=eagles")
+
+        assert response.status_code == status.HTTP_504_GATEWAY_TIMEOUT
+        assert "timeout" in response.json()["detail"].lower()
+
+    def test_predict_game_case_insensitive(self, client):
+        """Test that team names are case-insensitive."""
+        with patch("httpx.AsyncClient.get") as mock_get:
+            mock_response = AsyncMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "home_team": "chiefs",
+                "away_team": "eagles",
+                "home_win_probability": 0.62,
+                "away_win_probability": 0.38,
+                "predicted_spread": -3.5,
+                "model_version": "v1.0",
+                "feature_version": "v1.0",
+                "edge_vs_market": 0.04,
+                "recommended_bet_size": 0.025,
+                "bet_recommendation": "BET"
+            }
+            mock_response.raise_for_status = AsyncMock()
+            mock_get.return_value = mock_response
+
+            # Test with uppercase
+            response = client.get("/predictions/predict?team1=CHIEFS&team2=EAGLES")
+            assert response.status_code == status.HTTP_200_OK
+
+
+class TestBacktestEndpoint:
+    """Tests for GET /predictions/backtest/{run_id} endpoint."""
+
+    @patch("httpx.AsyncClient.get")
+    @pytest.mark.asyncio
+    async def test_get_backtest_results_success(self, mock_get, client):
+        """Test successful backtest results retrieval."""
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "run_id": "test-run-123",
+            "start_date": "2024-09-01",
+            "end_date": "2024-12-31",
+            "total_games": 256,
+            "correct_predictions": 165,
+            "accuracy": 0.644,
+            "total_profit": 1250.50,
+            "roi": 0.125,
+            "sharpe_ratio": 1.8
+        }
+        mock_response.raise_for_status = AsyncMock()
+        mock_get.return_value = mock_response
+
+        response = client.get("/predictions/backtest/test-run-123")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["run_id"] == "test-run-123"
+        assert data["total_games"] == 256
+        assert data["accuracy"] == 0.644
+
+    @patch("httpx.AsyncClient.get")
+    @pytest.mark.asyncio
+    async def test_get_backtest_results_not_found(self, mock_get, client):
+        """Test backtest results retrieval when run_id doesn't exist."""
+        mock_response = AsyncMock()
+        mock_response.status_code = 404
+        mock_response.text = "Not found"
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Not found", request=AsyncMock(), response=mock_response
+        )
+        mock_get.return_value = mock_response
+
+        response = client.get("/predictions/backtest/nonexistent-run")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert "not found" in response.json()["detail"].lower()
+
+    @patch("httpx.AsyncClient.get")
+    @pytest.mark.asyncio
+    async def test_get_backtest_results_service_unavailable(self, mock_get, client):
+        """Test backtest results when model service is unavailable."""
+        mock_get.side_effect = httpx.ConnectError("Connection refused")
+
+        response = client.get("/predictions/backtest/test-run-123")
+
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert "Model service unavailable" in response.json()["detail"]
+
+
+class TestModelsEndpoint:
+    """Tests for GET /predictions/models endpoint."""
+
+    @patch("httpx.AsyncClient.get")
+    @pytest.mark.asyncio
+    async def test_list_models_success(self, mock_get, client):
+        """Test successful models list retrieval."""
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "models": [
+                {
+                    "model_id": "model-001",
+                    "model_version": "v1.0",
+                    "feature_version": "v1.0",
+                    "trained_date": "2024-01-15",
+                    "accuracy": 0.652,
+                    "is_active": True
+                },
+                {
+                    "model_id": "model-002",
+                    "model_version": "v1.1",
+                    "feature_version": "v1.1",
+                    "trained_date": "2024-02-01",
+                    "accuracy": 0.668,
+                    "is_active": False
+                }
+            ]
+        }
+        mock_response.raise_for_status = AsyncMock()
+        mock_get.return_value = mock_response
+
+        response = client.get("/predictions/models")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert "models" in data
+        assert len(data["models"]) == 2
+        assert data["models"][0]["model_id"] == "model-001"
+        assert data["models"][0]["is_active"] is True
+
+    @patch("httpx.AsyncClient.get")
+    @pytest.mark.asyncio
+    async def test_list_models_empty(self, mock_get, client):
+        """Test models list retrieval when no models exist."""
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"models": []}
+        mock_response.raise_for_status = AsyncMock()
+        mock_get.return_value = mock_response
+
+        response = client.get("/predictions/models")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["models"] == []
+
+    @patch("httpx.AsyncClient.get")
+    @pytest.mark.asyncio
+    async def test_list_models_service_unavailable(self, mock_get, client):
+        """Test models list when model service is unavailable."""
+        mock_get.side_effect = httpx.ConnectError("Connection refused")
+
+        response = client.get("/predictions/models")
+
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert "Model service unavailable" in response.json()["detail"]


### PR DESCRIPTION
Implements Issue #2: Wire Prediction Routes to beat-books-model Service

### Changes
- Add GET /predictions/predict with NFL team validation
- Add GET /predictions/backtest/{run_id} for backtest results
- Add GET /predictions/models to list available models
- Add Pydantic response models with proper validation
- Add comprehensive E2E tests with mocked service responses
- All routes delegate to MODEL_SERVICE_URL (localhost:8002)
- Proper error handling (400, 404, 503, 504 status codes)

### Testing
Run tests with: `pytest tests/test_routes/test_predictions.py`

Closes #2

Generated with [Claude Code](https://claude.ai/code)