### PR TITLE
feat: wire data retrieval routes to beat-books-data service

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ httpx
 pydantic
 pydantic-settings
 pytest
+pytest-asyncio
 pytest-cov

--- a/src/core/client.py
+++ b/src/core/client.py
@@ -1,0 +1,65 @@
+"""HTTP client for communicating with beat-books-data service."""
+import httpx
+from typing import Optional, Dict, Any
+from fastapi import HTTPException
+from src.core.config import settings
+
+
+class DataServiceClient:
+    """Client for making requests to beat-books-data service."""
+
+    def __init__(self):
+        self.base_url = settings.DATA_SERVICE_URL
+        self.timeout = 30.0
+
+    async def _make_request(
+        self,
+        method: str,
+        endpoint: str,
+        params: Optional[Dict[str, Any]] = None,
+        json_data: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Make HTTP request to data service."""
+        url = f"{self.base_url}{endpoint}"
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.request(
+                    method=method, url=url, params=params, json=json_data
+                )
+                response.raise_for_status()
+                return response.json()
+
+        except httpx.HTTPStatusError as e:
+            # Forward the error from the data service
+            raise HTTPException(
+                status_code=e.response.status_code,
+                detail=e.response.json() if e.response.text else {"error": str(e)},
+            )
+        except httpx.RequestError as e:
+            # Connection errors, timeouts, etc.
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "error": {
+                        "code": "SERVICE_UNAVAILABLE",
+                        "message": f"Unable to connect to data service: {str(e)}",
+                    }
+                },
+            )
+
+    async def get(
+        self, endpoint: str, params: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Make GET request."""
+        return await self._make_request("GET", endpoint, params=params)
+
+    async def post(
+        self, endpoint: str, json_data: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Make POST request."""
+        return await self._make_request("POST", endpoint, json_data=json_data)
+
+
+# Singleton instance
+data_client = DataServiceClient()

--- a/src/core/enums.py
+++ b/src/core/enums.py
@@ -1,0 +1,13 @@
+"""Enums for API validation."""
+from enum import Enum
+
+
+class Position(str, Enum):
+    """NFL player positions."""
+
+    QB = "QB"
+    RB = "RB"
+    WR = "WR"
+    TE = "TE"
+    K = "K"
+    DEF = "DEF"

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -1,0 +1,34 @@
+"""Response models for consistent API responses."""
+from typing import Generic, TypeVar, Optional
+from pydantic import BaseModel
+
+T = TypeVar("T")
+
+
+class PaginationMeta(BaseModel):
+    """Pagination metadata."""
+
+    page: int
+    limit: int
+    total: int
+    total_pages: int
+
+
+class SuccessResponse(BaseModel, Generic[T]):
+    """Standard success response envelope."""
+
+    data: T
+    pagination: Optional[PaginationMeta] = None
+
+
+class ErrorDetail(BaseModel):
+    """Error details."""
+
+    code: str
+    message: str
+
+
+class ErrorResponse(BaseModel):
+    """Standard error response envelope."""
+
+    error: ErrorDetail

--- a/src/routes/scrape.py
+++ b/src/routes/scrape.py
@@ -1,28 +1,25 @@
 from fastapi import APIRouter
+from src.core.client import data_client
 
 router = APIRouter()
 
-# TODO: Wire these to beat-books-data service
-# Option A (now): pip install -e ../beat-books-data and import directly
-# Option B (later): HTTP calls to beat-books-data at localhost:8001
-
 
 @router.get("/{team}/{year}")
-def scrape_team(team: str, year: int):
+async def scrape_team(team: str, year: int):
     """Trigger scraping for a single team/year. Delegates to beat-books-data."""
-    # TODO: Call beat-books-data scrape service
-    return {"message": f"Scrape {team}/{year} — not yet wired to beat-books-data"}
+    result = await data_client.get(f"/scrape/{team}/{year}")
+    return result
 
 
 @router.get("/{year}")
-def scrape_year(year: int):
+async def scrape_year(year: int):
     """Trigger scraping for all teams in a year. Delegates to beat-books-data."""
-    # TODO: Call beat-books-data scrape service
-    return {"message": f"Scrape all teams for {year} — not yet wired to beat-books-data"}
+    result = await data_client.get(f"/scrape/{year}")
+    return result
 
 
 @router.post("/excel")
-def scrape_excel():
+async def scrape_excel():
     """Trigger batch scraping from Excel file. Delegates to beat-books-data."""
-    # TODO: Call beat-books-data excel scraper service
-    return {"message": "Excel scrape — not yet wired to beat-books-data"}
+    result = await data_client.post("/scrape/excel")
+    return result

--- a/src/routes/stats.py
+++ b/src/routes/stats.py
@@ -1,41 +1,52 @@
+from typing import Optional
 from fastapi import APIRouter, Query
+from src.core.client import data_client
+from src.core.enums import Position
 
 router = APIRouter()
 
-# TODO: Wire these to beat-books-data retrieval service
-
 
 @router.get("/teams/{team}/stats")
-def get_team_stats(team: str, season: int = Query(..., ge=1920, le=2100)):
+async def get_team_stats(team: str, season: int = Query(..., ge=1920, le=2100)):
     """Get team statistics. Delegates to beat-books-data."""
-    # TODO: Call beat-books-data stats retrieval service
-    return {"message": f"Stats for {team} season {season} — not yet wired"}
+    result = await data_client.get(
+        f"/stats/teams/{team}", params={"season": season}
+    )
+    return result
 
 
 @router.get("/players")
-def get_players(
+async def get_players(
     season: int = Query(..., ge=1920, le=2100),
-    position: str = Query(None),
+    position: Optional[Position] = Query(None),
     page: int = Query(1, ge=1),
     limit: int = Query(50, ge=1, le=200),
 ):
     """Get player statistics with filtering. Delegates to beat-books-data."""
-    # TODO: Call beat-books-data stats retrieval service
-    return {"message": "Player stats — not yet wired"}
+    params = {"season": season, "page": page, "limit": limit}
+    if position:
+        params["position"] = position.value
+
+    result = await data_client.get("/stats/players", params=params)
+    return result
 
 
 @router.get("/games")
-def get_games(
+async def get_games(
     season: int = Query(..., ge=1920, le=2100),
-    week: int = Query(None, ge=1, le=22),
+    week: Optional[int] = Query(None, ge=1, le=22),
 ):
     """Get game results. Delegates to beat-books-data."""
-    # TODO: Call beat-books-data stats retrieval service
-    return {"message": "Games — not yet wired"}
+    params = {"season": season}
+    if week is not None:
+        params["week"] = week
+
+    result = await data_client.get("/stats/games", params=params)
+    return result
 
 
 @router.get("/standings")
-def get_standings(season: int = Query(..., ge=1920, le=2100)):
+async def get_standings(season: int = Query(..., ge=1920, le=2100)):
     """Get season standings. Delegates to beat-books-data."""
-    # TODO: Call beat-books-data stats retrieval service
-    return {"message": "Standings — not yet wired"}
+    result = await data_client.get("/stats/standings", params={"season": season})
+    return result

--- a/tests/test_routes/test_scrape.py
+++ b/tests/test_routes/test_scrape.py
@@ -1,0 +1,116 @@
+"""E2E tests for scrape routes."""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+class TestScrapeRoutes:
+    """Tests for scraping endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_scrape_team_success(self, client):
+        """Test scraping a single team/year."""
+        with patch(
+            "src.routes.scrape.data_client.get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = {
+                "data": {"team": "KC", "year": 2024, "status": "completed"},
+                "pagination": None,
+            }
+
+            response = client.get("/scrape/KC/2024")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["data"]["team"] == "KC"
+            assert data["data"]["year"] == 2024
+            assert data["data"]["status"] == "completed"
+            mock_get.assert_called_once_with("/scrape/KC/2024")
+
+    @pytest.mark.asyncio
+    async def test_scrape_year_success(self, client):
+        """Test scraping all teams for a year."""
+        with patch(
+            "src.routes.scrape.data_client.get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = {
+                "data": {
+                    "year": 2024,
+                    "teams_scraped": 32,
+                    "status": "completed",
+                },
+                "pagination": None,
+            }
+
+            response = client.get("/scrape/2024")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["data"]["year"] == 2024
+            assert data["data"]["teams_scraped"] == 32
+            mock_get.assert_called_once_with("/scrape/2024")
+
+    @pytest.mark.asyncio
+    async def test_scrape_excel_success(self, client):
+        """Test batch scraping from Excel file."""
+        with patch(
+            "src.routes.scrape.data_client.post", new_callable=AsyncMock
+        ) as mock_post:
+            mock_post.return_value = {
+                "data": {
+                    "status": "completed",
+                    "rows_processed": 100,
+                },
+                "pagination": None,
+            }
+
+            response = client.post("/scrape/excel")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["data"]["status"] == "completed"
+            assert data["data"]["rows_processed"] == 100
+            mock_post.assert_called_once_with("/scrape/excel")
+
+    @pytest.mark.asyncio
+    async def test_scrape_service_unavailable(self, client):
+        """Test handling data service unavailability."""
+        from fastapi import HTTPException
+
+        with patch(
+            "src.routes.scrape.data_client.get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.side_effect = HTTPException(
+                status_code=503,
+                detail={
+                    "error": {
+                        "code": "SERVICE_UNAVAILABLE",
+                        "message": "Unable to connect to data service",
+                    }
+                },
+            )
+
+            response = client.get("/scrape/KC/2024")
+
+            assert response.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_scrape_not_found(self, client):
+        """Test handling 404 from data service."""
+        from fastapi import HTTPException
+
+        with patch(
+            "src.routes.scrape.data_client.get", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.side_effect = HTTPException(
+                status_code=404,
+                detail={
+                    "error": {
+                        "code": "NOT_FOUND",
+                        "message": "Team not found",
+                    }
+                },
+            )
+
+            response = client.get("/scrape/INVALID/2024")
+
+            assert response.status_code == 404

--- a/tests/test_routes/test_stats.py
+++ b/tests/test_routes/test_stats.py
@@ -1,0 +1,138 @@
+"""E2E tests for stats routes."""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+class TestStatsRoutes:
+    """Tests for statistics endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_get_team_stats_success(self, client):
+        """Test getting team stats with valid parameters."""
+        with patch("src.routes.stats.data_client.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {
+                "data": {"team": "KC", "season": 2024, "wins": 14, "losses": 3},
+                "pagination": None,
+            }
+
+            response = client.get("/teams/KC/stats?season=2024")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["data"]["team"] == "KC"
+            assert data["data"]["season"] == 2024
+            mock_get.assert_called_once_with("/stats/teams/KC", params={"season": 2024})
+
+    @pytest.mark.asyncio
+    async def test_get_team_stats_invalid_season(self, client):
+        """Test getting team stats with invalid season."""
+        response = client.get("/teams/KC/stats?season=1800")
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_get_players_success(self, client):
+        """Test getting players with filtering."""
+        with patch("src.routes.stats.data_client.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {
+                "data": [
+                    {"name": "Patrick Mahomes", "position": "QB", "team": "KC"},
+                    {"name": "Josh Allen", "position": "QB", "team": "BUF"},
+                ],
+                "pagination": {"page": 1, "limit": 50, "total": 2, "total_pages": 1},
+            }
+
+            response = client.get("/players?season=2024&position=QB&page=1&limit=50")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data["data"]) == 2
+            assert data["pagination"]["total"] == 2
+            mock_get.assert_called_once_with(
+                "/stats/players",
+                params={"season": 2024, "page": 1, "limit": 50, "position": "QB"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_players_invalid_position(self, client):
+        """Test getting players with invalid position."""
+        response = client.get("/players?season=2024&position=INVALID")
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_get_players_invalid_pagination(self, client):
+        """Test getting players with invalid pagination."""
+        response = client.get("/players?season=2024&page=0")
+        assert response.status_code == 422
+
+        response = client.get("/players?season=2024&limit=300")
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_get_games_success(self, client):
+        """Test getting games."""
+        with patch("src.routes.stats.data_client.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {
+                "data": [
+                    {"home_team": "KC", "away_team": "BUF", "week": 1, "season": 2024},
+                ],
+                "pagination": None,
+            }
+
+            response = client.get("/games?season=2024&week=1")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data["data"]) == 1
+            mock_get.assert_called_once_with(
+                "/stats/games", params={"season": 2024, "week": 1}
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_games_without_week(self, client):
+        """Test getting all games without week filter."""
+        with patch("src.routes.stats.data_client.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {"data": [], "pagination": None}
+
+            response = client.get("/games?season=2024")
+
+            assert response.status_code == 200
+            mock_get.assert_called_once_with("/stats/games", params={"season": 2024})
+
+    @pytest.mark.asyncio
+    async def test_get_games_invalid_week(self, client):
+        """Test getting games with invalid week."""
+        response = client.get("/games?season=2024&week=30")
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_get_standings_success(self, client):
+        """Test getting standings."""
+        with patch("src.routes.stats.data_client.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {
+                "data": [
+                    {"team": "KC", "wins": 14, "losses": 3, "division": "AFC West"},
+                    {"team": "BUF", "wins": 13, "losses": 4, "division": "AFC East"},
+                ],
+                "pagination": None,
+            }
+
+            response = client.get("/standings?season=2024")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data["data"]) == 2
+            mock_get.assert_called_once_with(
+                "/stats/standings", params={"season": 2024}
+            )
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self, client):
+        """Test handling empty results."""
+        with patch("src.routes.stats.data_client.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = {"data": [], "pagination": None}
+
+            response = client.get("/players?season=2024")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["data"] == []


### PR DESCRIPTION
## Summary

Wired all route stubs in `src/routes/stats.py` and `src/routes/scrape.py` to the beat-books-data service using HTTP calls. The API now properly delegates to the data service while maintaining a thin layer with no business logic.

## Changes

- Created HTTP client for beat-books-data communication (`src/core/client.py`)
- Implemented response envelope models (`src/core/models.py`)
- Added Position enum for input validation (`src/core/enums.py`)
- Wired all stats routes (teams, players, games, standings)
- Wired all scrape routes (team, year, excel)
- Added comprehensive E2E tests for both route modules
- Added pytest-asyncio dependency

## Testing

All routes are covered by E2E tests that verify:
- Happy path responses
- Input validation (422 errors)
- Empty results handling
- Service error handling

Resolves #1

🤖 Generated with [Claude Code](https://claude.ai/code)